### PR TITLE
UI: fix crash on lazy consortia load

### DIFF
--- a/packages/coinstac-ui/app/render/components/dashboard/dashboard-pipeline-nav-bar.jsx
+++ b/packages/coinstac-ui/app/render/components/dashboard/dashboard-pipeline-nav-bar.jsx
@@ -52,7 +52,7 @@ class DashboardPipelineNavBar extends React.Component {
     const { localRuns, consortia } = this.props;
     const { runId } = this.state;
 
-    if (!consortia || !localRuns) {
+    if (!consortia || consortia.length === 0 || !localRuns) {
       return;
     }
 
@@ -64,12 +64,13 @@ class DashboardPipelineNavBar extends React.Component {
 
       if (lastRun) {
         const consortium = consortia.find(c => c.id === lastRun.consortiumId);
-
-        this.setState({
-          runId: lastRun.id,
-          consortiumName: consortium.name,
-          pipelineName: lastRun.pipelineSnapshot.name,
-        });
+        if (consortium) {
+          this.setState({
+            runId: lastRun.id,
+            consortiumName: consortium.name,
+            pipelineName: lastRun.pipelineSnapshot.name,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Passes e2e testing
- [x] Passes lint
- [x] Docs have been added / updated if necessary (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Hotfix


* **What is the current behavior?** (You can also link to an open issue here)
referenced issue(s):
Sometimes when there are runs on a consortium(a?) they load before the consortia docs load, causing a crash on dashboard


* **What is the new behavior (if this is a feature change)?**
Add a conditional check for presence of docs


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

